### PR TITLE
X0 Scan

### DIFF
--- a/bin/analyzer.cpp
+++ b/bin/analyzer.cpp
@@ -243,13 +243,13 @@ int main(int argc, char** argv)
 
     sprintf(str_cut_sig, "charge[%d] > %d", MCPNumber, treshold.at(MCPNumber));
     sprintf(str_cut_trig0, "charge[%d] > %d", trigPos1, treshold.at(trigPos1));
-    sprintf(str_cut_tdc, "1==1"); //selection OFF
+    //sprintf(str_cut_tdc, "1==1"); //selection OFF
     sprintf(str_cut_saturated, "amp_max[%d] > 3450", MCPNumber);
-    sprintf(str_cut_nFibers, "1==1"); //selection OFF
+    //sprintf(str_cut_nFibers, "1==1"); //selection OFF
     sprintf(str_cut_trig_not_sat, "amp_max[%d] < 3450", trigPos1); 
     sprintf(str_cut_bad_timeCFD, "time_start_150[%d] != -20", MCPNumber);
     //    sprintf(str_cut_sci, "sci_front_adc > 400 && sci_front_adc <550");
-    sprintf(str_cut_multiplicity, "sci_front_adc > 80 && sci_front_adc < 330 && bgo_back_adc > 420 && bgo_back_adc < 640");
+    sprintf(str_cut_multiplicity, "sci_front_adc > 80 && sci_front_adc < 300");// && bgo_back_adc > 420 && bgo_back_adc < 640");
 
     /*    if (MCPList.at(MCP)==4)
     {
@@ -309,8 +309,8 @@ int main(int argc, char** argv)
         //---efficiency
         sprintf(h_sig_name, "h_sig_%d", i);
         sprintf(h_trig0_name, "h_trig0_%d", i);
-        TH1F* h_sig= new TH1F(h_sig_name, h_sig_name, 500, -5000, 25000);
-        TH1F* h_trig0 = new TH1F(h_trig0_name, h_trig0_name, 500, -5000, 25000);
+        TH1F* h_sig= new TH1F(h_sig_name, h_sig_name, 500, -5000, 40000);
+        TH1F* h_trig0 = new TH1F(h_trig0_name, h_trig0_name, 500, -5000, 40000);
         //---TOT        
         char TOT_diff[100];
         sprintf(TOT_diff, "(time_stop_150[%d]-time_start_150[%d])", MCPNumber, MCPNumber);
@@ -424,8 +424,8 @@ int main(int argc, char** argv)
             sprintf(var_trig0, "charge[%d]>>%s", trigPos1, h_trig0_name);
             nt->Draw(var_sig, cut_trig0 && cut_sig && cut_scan && cut_tdc && cut_nFibers && cut_multiplicity, "goff");
             nt->Draw(var_trig0, cut_trig0 && cut_scan && cut_tdc && cut_nFibers && cut_tdc && cut_multiplicity, "goff");
-            float eff = h_sig->GetEntries()/h_trig0->GetEntries();
-            float e_eff = TMath::Sqrt((TMath::Abs(eff*(1-eff)))/h_trig0->GetEntries());
+            float eff = h_sig->Integral(0, h_sig->GetNbinsX()+1)/h_trig0->Integral(0, h_trig0->GetNbinsX()+1);
+            float e_eff = TMath::Sqrt((TMath::Abs(eff*(1-eff)))/h_trig0->Integral(0, h_trig0->GetNbinsX()+1));
             if(eff < 0)   
                 eff = 0;
 	    if(i == 0)

--- a/bin/dumper.cpp
+++ b/bin/dumper.cpp
@@ -344,7 +344,8 @@ int main (int argc, char** argv)
             }
 
             run_id = run;
-            X0     = CFG.GetOpt<float>("global", "nX0");
+
+            X0     = CFG.GetOpt<float>("global", "nX0", iRun);
 
             // positionTree->GetEntry(iEntry);
             // tdcX = (*TDCreco)[0];

--- a/cfg/HVScan3_double.cfg
+++ b/cfg/HVScan3_double.cfg
@@ -1,0 +1,38 @@
+<global>
+inputDir /storage/BTF2015/raw_data/
+outputFile /home/pigo/Work/FastTiming/iMCP/BTF_2015/iMCP_TB/ntuples/reco_HVScan3_double.root 
+
+nX0 0
+nRuns 9
+nChannels 3
+trigPos 4
+
+runs 1904 1905 1906 1907 1908 1909 1910 
+
+MCPs MultiAlkEm GaAsEm MiB2
+
+</global>
+
+<MiB2>
+digiChannel 4
+isPCON 1
+isTrigger 1
+HV 2700 2700 2700 2700 2700 2700 2700 
+HV2 2700 2700 2700 2700 2700 2700 2700 
+</MiB2>
+
+<GaAsEm>
+digiChannel 3
+isPCON 1
+isTrigger 0
+HV 3600 3550 3500 3450 3400 3350 3300 
+HV2 3300 3300 3300 3300 3300 3300 3300
+</GaAsEm>
+
+<MultiAlkEm>
+digiChannel 2
+isPCON 1
+isTrigger 0
+HV 3200 3150 3100 3050 3000 2950 2900
+HV2 2900 2900 2900 2900 2900 2900 2900 
+</MultiAlkEm>

--- a/cfg/HVScan3_emitter.cfg
+++ b/cfg/HVScan3_emitter.cfg
@@ -1,0 +1,38 @@
+<global>
+inputDir /storage/BTF2015/raw_data/
+outputFile /home/pigo/Work/FastTiming/iMCP/BTF_2015/iMCP_TB/ntuples/reco_HVScan3_emitter.root 
+
+nX0 0
+nRuns 9
+nChannels 3
+trigPos 4
+
+runs 1900 1901 1904 1905 1906 1907 1908 1909 1910 
+
+MCPs MultiAlkEm GaAsEm MiB2
+
+</global>
+
+<MiB2>
+digiChannel 4
+isPCON 1
+isTrigger 1
+HV 2700 2700 2700 2700 2700 2700 2700 2700 2700 
+HV2 2700 2700 2700 2700 2700 2700 2700 2700 2700 
+</MiB2>
+
+<Double9090>
+digiChannel 3
+isPCON 1
+isTrigger 0
+HV 2700 2700 2700 2700 2700 2700 2700 2700 2700 
+HV2 1650 1650 1650 1600 1550 1500 1450 1400 1350 
+</Double9040>
+
+<Double9040>
+digiChannel 2
+isPCON 1
+isTrigger 0
+HV 2700 2700 2700 2700 2700 2700 2700 2700 2700 
+HV2 1650 1650 1650 1600 1550 1500 1450 1400 1350 
+</Double9040>

--- a/cfg/HVScan4_double.cfg
+++ b/cfg/HVScan4_double.cfg
@@ -1,0 +1,38 @@
+<global>
+inputDir /storage/BTF2015/raw_data/
+outputFile /home/pigo/Work/FastTiming/iMCP/BTF_2015/iMCP_TB/ntuples/reco_HVScan4_double.root 
+
+nX0 0
+nRuns 7
+nChannels 3
+trigPos 4
+
+runs 1912 1913 1914 1916 1917 1918 1919
+
+MCPs Double9090 Double9040 MiB2
+
+</global>
+
+<MiB2>
+digiChannel 4
+isPCON 1
+isTrigger 1
+HV 2700 2700 2700 2700 2700 2700 2700 
+HV2 2700 2700 2700 2700 2700 2700 2700 
+</MiB2>
+
+<Double9090>
+digiChannel 1
+isPCON 0
+isTrigger 0
+HV 2700 2600 2500 2400 2300 2200 2100
+HV2 2700 2700 2700 2700 2700 2700 2700 
+</Double9090>
+
+<Double9040>
+digiChannel 0
+isPCON 0
+isTrigger 0
+HV 2700 2600 2500 2400 2300 2200 2100
+HV2 2700 2700 2700 2700 2700 2700 2700 
+</Double9040>

--- a/cfg/HVScan4_emitter.cfg
+++ b/cfg/HVScan4_emitter.cfg
@@ -1,0 +1,38 @@
+<global>
+inputDir /storage/BTF2015/raw_data/
+outputFile /home/pigo/Work/FastTiming/iMCP/BTF_2015/iMCP_TB/ntuples/reco_HVScan4_emitter.root 
+
+nX0 0
+nRuns 7
+nChannels 3
+trigPos 4
+
+runs 1912 1913 1914 1916 1917 1918 1919
+
+MCPs MultiAlkEm GaAsEm MiB2
+
+</global>
+
+<MiB2>
+digiChannel 4
+isPCON 1
+isTrigger 1
+HV 2700 2700 2700 2700 2700 2700 2700 
+HV2 2700 2700 2700 2700 2700 2700 2700 
+</MiB2>
+
+<GaAsEm>
+digiChannel 3
+isPCON 1
+isTrigger 0
+HV 3400 3350 3300 3250 3200 3150 3100
+HV2 3100 3100 3100 3100 3100 3100 3100 
+</GaAsEm>
+
+<MultiAlkEm>
+digiChannel 2
+isPCON 1
+isTrigger 0
+HV 3800 3750 3700 3650 3600 3550 3500
+HV2 3500 3500 3500 3500 3500 3500 3500 
+</MultiAlkEm>

--- a/cfg/HVScan4_emitter.cfg
+++ b/cfg/HVScan4_emitter.cfg
@@ -7,7 +7,7 @@ nRuns 7
 nChannels 3
 trigPos 4
 
-runs 1912 1913 1914 1916 1917 1918 1919
+runs 1912 1913 1914 1916 1917 1918 1919 
 
 MCPs MultiAlkEm GaAsEm MiB2
 

--- a/cfg/X0Scan1.cfg
+++ b/cfg/X0Scan1.cfg
@@ -1,0 +1,54 @@
+<global>
+inputDir /storage/BTF2015/raw_data/
+outputFile /home/pigo/Work/FastTiming/iMCP/BTF_2015/iMCP_TB/ntuples/reco_X0Scan1.root 
+
+nX0 0 1 2 3 4 5 6 7 
+nRuns 5
+nChannels 5
+trigPos 4
+
+runs 1933 1934 1939 1936 1937 1938 1939
+
+MCPs Double9090 Double9040 MultiAlkEm GaAsEm MiB2
+
+</global>
+
+<MiB2>
+digiChannel 4
+isPCON 1
+isTrigger 1
+HV 2700 2700 2700 2700 2700 2700 2700 2700 
+HV2 2700 2700 2700 2700 2700 2700 2700 2700
+</MiB2>
+
+<GaAsEm>
+digiChannel 3
+isPCON 1
+isTrigger 0
+HV 3100 3100 3100 3100 3100 3100 3100 3100
+HV2 2800 2800 2800 2800 2800 2800 2800 2800
+</GaAsEm>
+
+<MultiAlkEm>
+digiChannel 2
+isPCON 1
+isTrigger 0
+HV 3800 3800 3800 3800 3800 3800 3800 3800
+HV2 3500 3500 3500 3500 3500 3500 3500 3500
+</MultiAlkEm>
+
+<Double9090>
+digiChannel 1
+isPCON 0
+isTrigger 0
+HV 2500 2500 2500 2500 2500 2500 2500 2500
+HV2 2700 2700 2700 2700 2700 2700 2700 2700
+</Double9090>
+
+<Double9040>
+digiChannel 0
+isPCON 0
+isTrigger 0
+HV 2500 2500 2500 2500 2500 2500 2500 2500
+HV2 2700 2700 2700 2700 2700 2700 2700 2700
+</Double9040>

--- a/script/cp-data.sh
+++ b/script/cp-data.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir ${1}
+scp -r cmsdaq@192.168.189.82:/data/IMCP/DQM/${1}/*root ${1}


### PR DESCRIPTION
Dopo aver scelto un working point per le varie camere abbiamo iniziato lo scan in X0...le cose non tornano: l'efficenza scende partendo da 0X0 verso NX0.

La posizione su fascio sembra influire sull'efficenza (senza abs), ad esempio confrontandi HVScan1 con HVScan4 per GaAsEm, oppure le due double tra di loro.

Le ntuple sono copiate su hercules nel solito path, la copia dei raw-data invce procede lenta.
